### PR TITLE
BACK-1209: Convert console.log calls to logger() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
-### v0.2.0
-* Using local file logger instead of console.log() for output
+### v0.1.3
+* Added local file logger to hide `console.log()` debug prints
 * Updated copyrights
 
 ### v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.2.0
+* Using local file logger instead of console.log() for output
+* Updated copyrights
+
 ### v0.1.2
 * Updated license and copyrights
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+// Copyright (c) 2016, Kinvey, Inc. All rights reserved.
 //
 // This software is licensed to you under the Kinvey terms of service located at
 // http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this

--- a/lib/log/logger.coffee
+++ b/lib/log/logger.coffee
@@ -1,0 +1,51 @@
+# Copyright (c) 2016 Kinvey Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+fs = require('fs')
+util = require('util')
+config = require('config')
+
+# Append log messages to local file
+logStream = fs.createWriteStream('output.log', { flags: 'a' })
+
+# format a millisecond unix timestamp as a decimal number
+formatMsTimestamp = (timestamp) ->
+  timestamp += ""
+  return timestamp.slice(0, -3) + "." + timestamp.slice(-3)
+
+formatMsIsoTimestring = (timestamp) ->
+  return new Date(timestamp).toISOString()
+
+# Debug logger
+exports.DEBUG = (msg) ->
+  timestamp = Date.now()
+  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [DEBUG] #{msg}\n"
+
+# Info logger
+exports.INFO = (msg) ->
+  timestamp = Date.now()
+  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [INFO] #{msg}\n"
+
+# Warning logger
+exports.WARNING = (msg) ->
+  timestamp = Date.now()
+  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [WARN] #{msg}\n"
+
+# Error logger
+exports.ERROR = (msg) ->
+  timestamp = Date.now()
+  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [ERROR] #{msg}\n"
+
+# Fatal logger
+exports.FATAL = (msg) ->
+  timestamp = Date.now()
+  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [FATAL] #{msg}\n"

--- a/lib/log/logger.coffee
+++ b/lib/log/logger.coffee
@@ -17,35 +17,30 @@ config = require('config')
 # Append log messages to local file
 logStream = fs.createWriteStream('output.log', { flags: 'a' })
 
-# format a millisecond unix timestamp as a decimal number
-formatMsTimestamp = (timestamp) ->
-  timestamp += ""
-  return timestamp.slice(0, -3) + "." + timestamp.slice(-3)
-
 formatMsIsoTimestring = (timestamp) ->
   return new Date(timestamp).toISOString()
 
 # Debug logger
 exports.DEBUG = (msg) ->
   timestamp = Date.now()
-  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [DEBUG] #{msg}\n"
+  logStream.write "#{formatMsIsoTimestring(timestamp)} [DEBUG] #{msg}\n"
 
 # Info logger
 exports.INFO = (msg) ->
   timestamp = Date.now()
-  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [INFO] #{msg}\n"
+  logStream.write "#{formatMsIsoTimestring(timestamp)} [INFO] #{msg}\n"
 
 # Warning logger
 exports.WARNING = (msg) ->
   timestamp = Date.now()
-  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [WARN] #{msg}\n"
+  logStream.write "#{formatMsIsoTimestring(timestamp)} [WARN] #{msg}\n"
 
 # Error logger
 exports.ERROR = (msg) ->
   timestamp = Date.now()
-  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [ERROR] #{msg}\n"
+  logStream.write "#{formatMsIsoTimestring(timestamp)} [ERROR] #{msg}\n"
 
 # Fatal logger
 exports.FATAL = (msg) ->
   timestamp = Date.now()
-  logStream.write "#{formatMsIsoTimestring(timestamp)} #{formatMsTimestamp(timestamp)} [FATAL] #{msg}\n"
+  logStream.write "#{formatMsIsoTimestring(timestamp)} [FATAL] #{msg}\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinvey-code-task-runner",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Task Runner for Kinvey Microservices",
   "engines": { "node": "= 0.10.x" },
   "repository"   : { "type": "git", "url": "Kinvey/kinvey-task-receiver" },


### PR DESCRIPTION
This PR adds a new logger() module which sends logging output to a local file (opened in 'append' mode). Replaced all console.log calls with respective logger calls in order to filter out this output from internal DLC logs. Currently-running containers can be hijacked in order to view task-receiver log messages